### PR TITLE
Remove file extensions to load as modules

### DIFF
--- a/lib/heart.js
+++ b/lib/heart.js
@@ -1,5 +1,5 @@
-var Pulse = require('./pulse.js');
-var BeatEvent = require('./beatevent.js');
+var Pulse = require('./pulse');
+var BeatEvent = require('./beatevent');
 
 var idCount = 0,
     hearts;

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 var hearts = {};
-var Heart = require('./lib/heart.js').initialize(hearts);
+var Heart = require('./lib/heart').initialize(hearts);
 
 function createHeart(heartrate, name) {
     var heart = new Heart(heartrate, name);


### PR DESCRIPTION
Removed the file extensions from the `require` calls so that files are
loaded up correctly as modules and don’t lose their module path.

Resolves: https://github.com/arjunmehta/heartbeats/issues/6